### PR TITLE
Make cherrys work with modern redis and cherrypy version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,22 +56,23 @@ It is that simple!
 Config dictionary
 =================
 
-There are 4 optional parameters you can set:
+There are a few optional parameters you can set:
 
 + **host** *[127.0.0.1]* (when is_sentinel this is host for sentinel service)
 + **port** *[6379]* (when is_sentinel this is port for sentinel service)
 + **ssl** *[False]* (for both sentinel and redis)
-+ **tls_skip_verify** *[False]* (for both sentinel and redis)
++ **db** *[0]*
++ **prefix** *[""]* (prepended to session id if given; useful when ACLs are enabled)
++ **user** *[None]* (for old version of authentication can be set to empty string)
++ **password** *[None]*
++ **url** *[None]* (alternative to host/port/ssl/db/user/password combination)
+
+Sentinel-related additional (optional) parameters:
 
 + **is_sentinel** *[False]*
 + **sentinel_pass** *[None]*
 + **sentinel_service** *[None]*
-
-+ **db** *[0]*
-+ **prefix** *['cherrys_']* (prepended to session if, useful when ACLs are enabled)
-+ **user** *[None]* (for old version of authentication can be set to empty string)
-+ **password** *[None]*
-
++ **tls_skip_verify** *[False]*
 
 
 A full config dictionary to activate Redis_ backed sessions would look like
@@ -90,7 +91,7 @@ this.
         'tools.sessions.prefix': REDIS_PREFIX,
         'tools.sessions.user': REDIS_USER,
         'tools.sessions.password': REDIS_PASS,
-        }
+    }
 
 A full config dictionary to activate RedisSentinelSSL_ backed sessions would look like
 this.
@@ -104,19 +105,45 @@ this.
         'tools.sessions.host': REDIS_HOST,
         'tools.sessions.port': REDIS_PORT,
         'tools.sessions.ssl': True,
-        'tools.sessions.tls_skip_verify': True,
-
-        'tools.sessions.is_sentinel': True,
-        'tools.sessions.sentinel_pass': REDIS_SENTINEL_PASS,
-        'tools.sessions.sentinel_service': REDIS_SENTINEL_SERVICENAME,
 
         'tools.sessions.db': REDIS_DB,
         'tools.sessions.prefix': REDIS_PREFIX,
         'tools.sessions.user': REDIS_USER,
         'tools.sessions.password': REDIS_PASS,
-        }
 
-.. _CherryPy: http://www.cherrypy.org
+        'tools.sessions.is_sentinel': True,
+        'tools.sessions.sentinel_pass': REDIS_SENTINEL_PASS,
+        'tools.sessions.sentinel_service': REDIS_SENTINEL_SERVICENAME,
+        'tools.sessions.tls_skip_verify': True,
+    }
+
+Configuration via redis URL
+===========================
+As a shortcut a URL to the redis server can be provided as well.
+
+::
+
+    import cherrys
+    config = {
+        'tools.sessions.on' : True,
+        # next setting removes the need for initializing `cherrypy.lib.sessions.RedisSession' above:
+        'tools.sessions.storage_class' : cherrys.RedisSession,
+        'tools.sessions.url': 'redis://your-name:your-pwd@redis-server:6379/2'
+    }
+
+The number at the end of the URL ("2") denotes the redis database to be used.
+
+Running unittests
+=================
+
+Unittests require a running redis-server on localhost:6379 setup without
+any authentication in place.
+
+Install pytest with `pip install pytest` into your current virtualenv.
+Then run `pytest` from your shell.
+
+
+.. _CherryPy: http://www.cherrypy.dev
 .. _PostgreSQL: http://www.postgresql.org
 .. _Memcached: http://memcached.org
 .. _Redis: http://redis.io

--- a/README.rst
+++ b/README.rst
@@ -139,8 +139,12 @@ Running unittests
 Unittests require a running redis-server on localhost:6379 setup without
 any authentication in place.
 
-Install pytest with `pip install pytest` into your current virtualenv.
-Then run `pytest` from your shell.
+Then install pytest into your current virtualenv and start it from your command line:
+
+::
+
+    $ pip install pytest
+    $ pytest
 
 
 .. _CherryPy: http://www.cherrypy.dev

--- a/cherrys.py
+++ b/cherrys.py
@@ -1,29 +1,42 @@
 """
 Cherrys is a Redis backend for CherryPy sessions.
 
-The redis server must support SETEX http://redis.io/commands/setex.
+The redis server must support SETEX https://redis.io/commands/setex.
 
 Relies on redis-py https://github.com/andymccurdy/redis-py.
 """
 
-import threading
-
 try:
-  import cPickle as pickle
+    import cPickle as pickle
 except ImportError:
-  import pickle
+    import pickle
 
-from cherrypy.lib.sessions import Session
 import redis
-from redis import Sentinel
+from cherrypy.lib.sessions import Session
+
+REDIS_PORT = 6379
+
 
 class RedisSession(Session):
-
     # the default settings
     host = '127.0.0.1'
-    port = 6379
+    port = REDIS_PORT
     db = 0
+    user = None
     password = None
+    url = None
+    ssl = False
+    is_sentinel = False
+    tls_skip_verify = False
+    prefix = ""
+    lock_prefix = "lock_"
+    ssl_cert_req = None
+    sentinel_pass = None
+    sentinel_service = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.lock = None
 
     @classmethod
     def setup(cls, **kwargs):
@@ -35,59 +48,63 @@ class RedisSession(Session):
         for k, v in kwargs.items():
             setattr(cls, k, v)
 
-        if cls.tls_skip_verify:
-            cls.ssl_cert_req=None
-        else:
-            cls.ssl_cert_req="required"
+        assert cls.prefix != cls.lock_prefix, "'prefix' must not be equal to 'lock_'"
+
+        if not cls.tls_skip_verify:
+            cls.ssl_cert_req = "required"
 
         if cls.is_sentinel:
-            sentinel = Sentinel([(cls.host, cls.port)], ssl=cls.ssl, ssl_cert_reqs=cls.ssl_cert_req, sentinel_kwargs={"password":cls.sentinel_pass, "ssl": cls.ssl, "ssl_cert_reqs": cls.ssl_cert_req}, username=cls.user, password=cls.password)
+            sentinel = redis.Sentinel(
+                [(cls.host, cls.port)],
+                ssl=cls.ssl,
+                ssl_cert_reqs=cls.ssl_cert_req,
+                sentinel_kwargs={
+                    "password": cls.sentinel_pass,
+                    "ssl": cls.ssl,
+                    "ssl_cert_reqs": cls.ssl_cert_req
+                },
+                username=cls.user,
+                password=cls.password)
             cls.cache = sentinel.master_for(cls.sentinel_service)
-            
+        elif cls.url:
+            cls.cache = redis.from_url(cls.url)
         else:
-            cls.cache = redis.from_url(
+            cls.cache = redis.Redis(
                 host=cls.host,
                 port=cls.port,
                 db=cls.db,
                 ssl=cls.ssl,
                 username=cls.user,
-                password=cls.password)
+                password=cls.password
+            )
 
     def _exists(self):
-        return bool(self.cache.exists(self.prefix+self.id))
+        return bool(self.cache.exists(self.prefix + self.id))
 
     def _load(self):
         try:
-          return pickle.loads(self.cache.get(self.prefix+self.id))
+            return pickle.loads(self.cache.get(self.prefix + self.id))
         except TypeError:
-          # if id not defined pickle can't load None and raise TypeError
-          return None
+            # if id not defined pickle can't load None and raise TypeError
+            return None
 
     def _save(self, expiration_time):
-        pickled_data = pickle.dumps(
-            (self._data, expiration_time),
-            pickle.HIGHEST_PROTOCOL)
-
-        result = self.cache.setex(self.prefix+self.id, self.timeout * 60, pickled_data)
+        pickled_data = pickle.dumps((self._data, expiration_time), pickle.HIGHEST_PROTOCOL)
+        result = self.cache.setex(self.prefix + self.id, self.timeout * 60, pickled_data)
 
         if not result:
-            raise AssertionError("Session data for id %r not set." % self.prefix+self.id)
+            raise AssertionError("Session data for id %r not set." % self.prefix + self.id)
 
     def _delete(self):
-        self.cache.delete(self.prefix+self.id)
-
-    # http://docs.cherrypy.org/dev/refman/lib/sessions.html?highlight=session#locking-sessions
-    # session id locks as done in RamSession
-
-    locks = {}
+        self.cache.delete(self.prefix + self.id)
 
     def acquire_lock(self):
-        """Acquire an exclusive lock on the currently-loaded session data."""
+        """Acquire an exclusive redis lock on the currently-loaded session data."""
         self.locked = True
-        self.locks.setdefault(self.prefix+self.id, threading.RLock()).acquire()
+        self.lock = self.cache.lock(self.lock_prefix + self.id)
+        self.lock.acquire()
 
     def release_lock(self):
         """Release the lock on the currently-loaded session data."""
-        self.locks[self.prefix+self.id].release()
+        self.lock.release()
         self.locked = False
-

--- a/cherrys.py
+++ b/cherrys.py
@@ -50,10 +50,10 @@ class RedisSession(Session):
 
         assert cls.prefix != cls.lock_prefix, "'prefix' must not be equal to 'lock_'"
 
-        if not cls.tls_skip_verify:
-            cls.ssl_cert_req = "required"
-
         if cls.is_sentinel:
+            if not cls.tls_skip_verify:
+                cls.ssl_cert_req = "required"
+
             sentinel = redis.Sentinel(
                 [(cls.host, cls.port)],
                 ssl=cls.ssl,
@@ -64,7 +64,8 @@ class RedisSession(Session):
                     "ssl_cert_reqs": cls.ssl_cert_req
                 },
                 username=cls.user,
-                password=cls.password)
+                password=cls.password
+            )
             cls.cache = sentinel.master_for(cls.sentinel_service)
         elif cls.url:
             cls.cache = redis.from_url(cls.url)

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,22 @@
 from setuptools import setup
 
-version = '0.5'
+version = '0.6.0a1'
 readme = open('README.rst').read()
 setup(
-    name = 'cherrys',
-    version = version,
-    description = 'Redis backend for CherryPy sessions',
-    long_description = readme,
-    long_description_content_type = 'text/x-rst',
-    py_modules = ['cherrys'],
-    license = 'MIT',
-    author = 'Eugene Van den Bulke',
-    author_email = 'eugene.vandenbulke@gmail.com',
-    url = 'http://github.com/3kwa/cherrys',
-    test_suite = 'test_cherrys',
-    install_requires = ['redis >= 2.4.9', 'cherrypy >= 3.2'],
-    classifiers = [
+    name='cherrys',
+    version=version,
+    description='Redis backend for CherryPy sessions',
+    long_description=readme,
+    long_description_content_type='text/x-rst',
+    py_modules=['cherrys'],
+    license='MIT',
+    author='Eugene Van den Bulke',
+    author_email='eugene.vandenbulke@gmail.com',
+    url='https://github.com/3kwa/cherrys',
+    test_suite='test_cherrys',
+    install_requires=['redis >= 3.5.0', 'cherrypy >= 18.0.0'],
+    test_requires=['pytest'],
+    classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: CherryPy',
@@ -23,6 +24,7 @@ setup(
         'License :: Freely Distributable',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
         'Topic :: Database',
         'Topic :: Internet :: WWW/HTTP :: Session']
 )

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = '0.6.0a1'
+version = '0.6.0a2'
 readme = open('README.rst').read()
 setup(
     name='cherrys',

--- a/test_cherrys.py
+++ b/test_cherrys.py
@@ -1,16 +1,16 @@
-import unittest
 import socket
+import time
+import threading
 
+import cherrys
 import cherrypy
-from cherrypy.test import webtest
+import pytest
+from cherrypy.test import helper
 
-# testing that redis-py is available and that we have a redis server running
-try:
-    import redis
 
-    host, port = '127.0.0.1', 6379
-    for res in socket.getaddrinfo(host, port, socket.AF_UNSPEC,
-                                  socket.SOCK_STREAM):
+def setup_module():
+    host, port = '127.0.0.1', cherrys.REDIS_PORT
+    for res in socket.getaddrinfo(host, port, socket.AF_UNSPEC, socket.SOCK_STREAM):
         af, socktype, proto, canonname, sa = res
         s = None
         try:
@@ -21,86 +21,118 @@ try:
         except socket.error:
             if s:
                 s.close()
-            raise
+            pytest.exit(f"Failed to connect to redis server", returncode=2)
         break
 
-except ImportError:
 
-  class RedisSessionTest(unittest.TestCase):
-      def test_nothing(self):
-          self.fail("redis-py not available")
+class RedisSessionTest(helper.CPWebCase):
+    """RedisSession unittest class - connect to redis via hostname/port"""
+    helper.CPWebCase.interactive = False
 
-except socket.error:
+    @staticmethod
+    def setup_server():
+        cherrypy.config.update({
+            'log.screen': False,  # set to True to see error stdout and errors from cp server
+            'tools.sessions.on': True,
+            'tools.session.host': "localhost",
+            'tools.session.port': cherrys.REDIS_PORT,
+            'tools.session.url': None,
+            'tools.sessions.storage_class': cherrys.RedisSession
+        })
+        cherrypy.tree.mount(App())
 
-  class RedisSessionTest(unittest.TestCase):
-      def test_nothing(self):
-          self.fail("redis not reachable")
+    def test_server_working(self):
+        self.getPage('/')
+        self.assertStatus(200)
 
-# all good to go we can test
-else:
+    def test_deleting_non_existing_key_fails(self):
+        self.getPage('/delete')
+        self.assertStatus(500)
 
-    import cherrys
-    cherrypy.lib.sessions.RedisSession = cherrys.RedisSession
+    def test_deleting_stored_data(self):
+        self.getPage('/store')
+        self.assertStatus(200)
+        # first getPage call sets a cookie
+        # second getPage call needs to be aware of the cookie
+        self.getPage('/delete', self.cookies)
+        self.assertStatus(200)
 
-    class RedisSessionTest(webtest.WebCase):
+    def test_storing_data(self):
+        self.getPage('/store?sleep=5')
+        self.assertStatus(200)
+        self.assertBody('redis')
 
-        interactive = False
+    def test_retrieving_stored_data(self):
+        self.getPage('/retrieve')
+        self.assertStatus(500)
+        self.getPage('/store', self.cookies)
+        self.assertStatus(200)
+        self.assertBody('redis')
+        self.getPage('/retrieve', self.cookies)
+        self.assertStatus(200)
 
-        @classmethod
-        def setUpClass(cls):
-            # configuring CP instead of webCase (getPage - openUrl on port 8000)
-            cherrypy.config.update({
-                'server.socket_port' : 8000,
-                'log.screen' : False,
-                'tools.sessions.on' : True,
-                'tools.sessions.storage_type' : 'redis'
-            })
-            cherrypy.tree.mount(App())
-            cherrypy.engine.start()
+    def test_locked_session(self):
+        """Check that redis really holds a lock on a session.
 
-        def test_server_working(self):
-            self.getPage('/')
-            self.assertStatus(200)
+        This is achieved by sending two parallel requests with the same session id to
+        the cherrypy server. The first request makes the session block for SLEEP_SECS.
+        The second request should be forced to wait at least SLEEP_SECS before it
+        can be accomplished.
+        """
+        SLEEP_SECS = 1.0
+        self.getPage('/')
+        # Cookies must be stored locally to be usable in background thread:
+        cookies = self.cookies[:]
+        thread = threading.Thread(
+            target=self.getPage, args=[f'/store?sleep={SLEEP_SECS}', cookies]
+        )
+        thread.start()
 
-        def test_deleting_non_existing_key_fails(self):
-            self.getPage('/delete')
-            self.assertStatus(500)
+        t0 = time.time()
+        # Give background thread a chance to fire out the first request:
+        time.sleep(SLEEP_SECS / 4)
 
-        def test_deleting_stored_data(self):
-            self.getPage('/store')
-            self.assertStatus(200)
-            # first getPage call sets a cookie
-            # second getPage call needs to be aware of the cookie
-            self.getPage('/delete', self.cookies)
-            self.assertStatus(200)
+        # Then launch the 2nd request with the same session id:
+        self.getPage('/retrieve', cookies)
+        # This check ensures that the 2nd request indeed had to wait until the first
+        # request of the background thread (which blocked the session on the server
+        # side) actually has finished:
+        assert (time.time() - t0) >= SLEEP_SECS
 
-        def test_storing_data(self):
-            self.getPage('/store')
-            self.assertStatus(200)
-            self.assertBody('redis')
+        self.assertStatus(200)
+        self.assertBody('redis')
 
-        def test_retrieving_stored_data(self):
-            self.getPage('/retrieve')
-            self.assertStatus(500)
-            self.getPage('/store', self.cookies)
-            self.assertStatus(200)
-            self.assertBody('redis')
-            self.getPage('/retrieve', self.cookies)
-            self.assertStatus(200)
 
-        @classmethod
-        def tearDownClass(cls):
-            cherrypy.engine.exit()
+class RedisSessionTestViaUrl(RedisSessionTest):
+    """RedisSession unittest class - connect via redis-URL"""
 
-class App(object):
+    @staticmethod
+    def setup_server():
+        cherrypy.config.update({
+            'log.screen': False,  # set to True to see error stdout and errors from cp server
+            'tools.sessions.on': True,
+            'tools.session.host': None,
+            'tools.session.port': None,
+            'tools.session.url': "redis://localhost:6379/0",
+            'tools.sessions.storage_class': cherrys.RedisSession
+        })
+        cherrypy.tree.mount(App())
+
+
+class App:
     """ A basic application to test sessions """
+    app_data = None
 
     @cherrypy.expose
     def index(self):
+        assert isinstance(cherrypy.serving.session, cherrys.RedisSession)
+        cherrypy.session.load()
         return 'index'
 
     @cherrypy.expose
-    def store(self):
+    def store(self, sleep=None):
+        if sleep:
+            time.sleep(float(sleep))
         cherrypy.session['data'] = 'redis'
         return cherrypy.session['data']
 
@@ -112,6 +144,3 @@ class App(object):
     @cherrypy.expose
     def retrieve(self):
         return cherrypy.session['data']
-
-if __name__ == '__main__':
-  unittest.main()


### PR DESCRIPTION
Hi Eugene,
hope you accept this pull request to your really cool cherrypy redis-session package. The main changes are:

* Upgraded to Python 3 (only)
* Adapted you relatively up-to-date redis and cherrypy versions
* Support distributed session locking via redis locks
* Switched to pytest testing (cause cherrypy does the same)
* Support redis-url for connecting to redis server
* Setup sensible default values for optional connection parameters.
* Some code reformatting to fit pep8/flake8 styling requirements
* Updated documentation

I'm happy to discuss details.
Ralph