### PR TITLE
Check for session to be locked for i/o; session lock can expire

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -65,6 +65,7 @@ There are a few optional parameters you can set:
 + **prefix** *[""]* (prepended to session id if given; useful when ACLs are enabled)
 + **user** *[None]* (for old version of authentication can be set to empty string)
 + **password** *[None]*
++ **lock_timeout** *[None]* (None, or time in seconds until session lock expires)
 + **url** *[None]* (alternative to host/port/ssl/db/user/password combination)
 
 Sentinel-related additional (optional) parameters:
@@ -91,6 +92,7 @@ this.
         'tools.sessions.prefix': REDIS_PREFIX,
         'tools.sessions.user': REDIS_USER,
         'tools.sessions.password': REDIS_PASS,
+        'tools.sessions.lock_timeout: LOCK_TIME_SECONDS,
     }
 
 A full config dictionary to activate RedisSentinelSSL_ backed sessions would look like
@@ -110,6 +112,7 @@ this.
         'tools.sessions.prefix': REDIS_PREFIX,
         'tools.sessions.user': REDIS_USER,
         'tools.sessions.password': REDIS_PASS,
+        'tools.sessions.lock_timeout: LOCK_TIME_SECONDS,
 
         'tools.sessions.is_sentinel': True,
         'tools.sessions.sentinel_pass': REDIS_SENTINEL_PASS,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-version = '0.6.0a2'
+version = '0.6.0a3'
 readme = open('README.rst').read()
 setup(
     name='cherrys',

--- a/test_cherrys.py
+++ b/test_cherrys.py
@@ -1,6 +1,7 @@
 import socket
 import time
 import threading
+from unittest import mock
 
 import cherrys
 import cherrypy
@@ -101,6 +102,15 @@ class RedisSessionTest(helper.CPWebCase):
 
         self.assertStatus(200)
         self.assertBody('redis')
+
+    @mock.patch.object(cherrys.RedisSession, "lock_timeout", 1)
+    def test_session_lock_expires(self):
+        """Check that redis expires a session lock automatically after 1 second"""
+        # Wait for 2 secs just to be sure and avoid flaky tests:
+        self.getPage("/store?sleep=2")
+        # Grab assertion exception from body and check for correct server-side error message:
+        assert b"Cannot load data from unlocked session" in self.body
+        self.assertStatus(500)
 
 
 class RedisSessionTestViaUrl(RedisSessionTest):


### PR DESCRIPTION
This patch adds the possibility that lock can expire, which allows to avoid that a request can hang forever.
Also, the redis lock object is now used as sole source of truth for the locking state of a session.
This lock state is checked before all i/o operations (same way as the FileSession in cherrypy does it).
